### PR TITLE
Add TimeUnitConverter

### DIFF
--- a/tests/test_time_unit_converter.py
+++ b/tests/test_time_unit_converter.py
@@ -1,0 +1,61 @@
+import os
+import pytest
+from fractions import Fraction
+from pathlib import Path
+from video_timestamps import TimeUnitConverter
+
+dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
+
+
+def test_time_base_to_time_scale() -> None:
+    time_base = Fraction(1, 75)
+    expected_time_scale = Fraction(75)
+    assert TimeUnitConverter.time_base_to_time_scale(time_base) == expected_time_scale
+
+    time_base = Fraction(24000, 1001)
+    expected_time_scale = Fraction(1001, 24000)
+    assert TimeUnitConverter.time_base_to_time_scale(time_base) == expected_time_scale
+
+
+def test_time_scale_to_time_base() -> None:
+    time_scale = Fraction(75)
+    expected_time_base = Fraction(1, 75)
+    assert TimeUnitConverter.time_scale_to_time_base(time_scale) == expected_time_base
+
+    time_scale = Fraction(1001, 24000)
+    expected_time_base = Fraction(24000, 1001)
+    assert TimeUnitConverter.time_scale_to_time_base(time_scale) == expected_time_base
+
+
+def test_timestamp_scale_to_time_scale() -> None:
+    timestamp_scale = 1000
+    expected_time_scale = Fraction(pow(10, 6))
+    assert TimeUnitConverter.timestamp_scale_to_time_scale(timestamp_scale) == expected_time_scale
+
+
+def test_time_scale_to_timestamp_scale() -> None:
+    time_scale = Fraction(pow(10, 6))
+    expected_timestamp_scale = 1000
+    assert TimeUnitConverter.time_scale_to_timestamp_scale(time_scale) == expected_timestamp_scale
+
+    time_scale = Fraction(90000)
+    with pytest.raises(ValueError) as exc_info:
+        TimeUnitConverter.time_scale_to_timestamp_scale(time_scale)
+    assert str(exc_info.value) == f"The timescale {time_scale} cannot be converted to a timestamp scale because the result 100000/9 isn't a integer."
+
+
+def test_timestamp_scale_to_time_base() -> None:
+    timestamp_scale = 1000
+    expected_time_base = Fraction(1, pow(10, 6))
+    assert TimeUnitConverter.timestamp_scale_to_time_base(timestamp_scale) == expected_time_base
+
+
+def test_time_base_to_timestamp_scale() -> None:
+    time_base = Fraction(1, pow(10, 6))
+    expected_timestamp_scale = 1000
+    assert TimeUnitConverter.time_base_to_timestamp_scale(time_base) == expected_timestamp_scale
+
+    time_base = Fraction(1, 90000)
+    with pytest.raises(ValueError) as exc_info:
+        TimeUnitConverter.time_base_to_timestamp_scale(time_base)
+    assert str(exc_info.value) == f"The timebase {time_base} cannot be converted to a timestamp scale because the result 100000/9 isn't a integer."

--- a/video_timestamps/__init__.py
+++ b/video_timestamps/__init__.py
@@ -7,4 +7,5 @@ from .fps_timestamps import *
 from .rounding_method import *
 from .text_file_timestamps import *
 from .time_type import *
+from .time_unit_converter import *
 from .video_timestamps import *

--- a/video_timestamps/time_unit_converter.py
+++ b/video_timestamps/time_unit_converter.py
@@ -1,0 +1,111 @@
+import sys
+from fractions import Fraction
+
+__all__ = ["TimeUnitConverter"]
+
+
+class TimeUnitConverter:
+    """Utility class for converting between time units."""
+
+    @staticmethod
+    def time_base_to_time_scale(time_base: Fraction) -> Fraction:
+        """
+        Convert a time base to a time scale.
+
+        Parameters:
+            time_base (Fraction): The time base to convert.
+
+        Returns:
+            The corresponding time scale.
+        """
+        return 1 / time_base
+    
+
+    @staticmethod
+    def time_scale_to_time_base(time_scale: Fraction) -> Fraction:
+        """
+        Convert a time scale to a time base.
+
+        Parameters:
+            time_scale (Fraction): The time scale to convert.
+
+        Returns:
+            The corresponding time base.
+        """
+        return 1 / time_scale
+
+
+    @staticmethod
+    def timestamp_scale_to_time_scale(timestamp_scale: int) -> Fraction:
+        """
+        Convert a timestamp scale to a time scale.
+
+        Parameters:
+            timestamp_scale (int): The timestamp scale (e.g., nanoseconds per tick).
+
+        Returns:
+            The corresponding time scale.
+        """
+        return Fraction(pow(10, 9), timestamp_scale)
+
+
+    @staticmethod
+    def time_scale_to_timestamp_scale(time_scale: Fraction) -> int:
+        """
+        Convert a time scale to a timestamp scale.
+
+        Parameters:
+            time_scale (Fraction): The time scale to convert.
+
+        Returns:
+            The corresponding timestamp scale.
+        """
+        timestamp_scale = Fraction(pow(10, 9), time_scale)
+
+        if sys.version_info >= (3, 12):
+            is_integer = timestamp_scale.is_integer()
+        else:
+            is_integer = timestamp_scale.denominator == 1
+        
+        if not is_integer:
+            raise ValueError(f"The timescale {time_scale} cannot be converted to a timestamp scale because the result {timestamp_scale} isn't a integer.")
+
+        return int(timestamp_scale)
+
+
+    @staticmethod
+    def timestamp_scale_to_time_base(timestamp_scale: int) -> Fraction:
+        """
+        Convert a timestamp scale to a time base.
+
+        Parameters:
+            timestamp_scale (int): The timestamp scale.
+
+        Returns:
+            The corresponding time base.
+        """
+        return Fraction(timestamp_scale, pow(10, 9))
+
+
+    @staticmethod
+    def time_base_to_timestamp_scale(time_base: Fraction) -> int:
+        """
+        Convert a time base to a timestamp scale.
+
+        Parameters:
+            time_base (Fraction): The time base to convert.
+
+        Returns:
+            The corresponding timestamp scale.
+        """
+        timestamp_scale = time_base * pow(10, 9)
+
+        if sys.version_info >= (3, 12):
+            is_integer = timestamp_scale.is_integer()
+        else:
+            is_integer = timestamp_scale.denominator == 1
+        
+        if not is_integer:
+            raise ValueError(f"The timebase {time_base} cannot be converted to a timestamp scale because the result {timestamp_scale} isn't a integer.")
+    
+        return int(timestamp_scale)


### PR DESCRIPTION
It is useful for people who don't have a time scale but want to instantiate an FPSTimestamps object using a time base or a timestamp scale.