### PR TITLE
Fix mypy error since version 1.20.0

### DIFF
--- a/video_timestamps/rounding_method.py
+++ b/video_timestamps/rounding_method.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from enum import Enum
+from enum import Enum, auto
 from fractions import Fraction
 from math import ceil, floor
 
@@ -20,12 +20,17 @@ def round_method(number: Fraction) -> int:
 class RoundingMethod(Enum):
     """Method used to adjust presentation timestamps (PTS).
     """
-    FLOOR = floor_method
+    FLOOR = auto()
     """Floor"""
 
-    ROUND = round_method
+    ROUND = auto()
     """Round half up"""
 
     def __call__(self, number: Fraction) -> int:
-        method: RoundingCallType = self.value
+        if self.value == self.FLOOR.value:
+            method = floor_method
+        elif self.value == self.ROUND.value:
+            method = round_method
+        else:
+            raise NotImplementedError(f"Rounding method {self} is not implemented.")
         return method(number)


### PR DESCRIPTION
Since the version 1.20.0, mypy reported many error about RoundingMethod:
```
tests/test_timestamps.py:18: error: Argument 1 to "FPSTimestamps" has incompatible type "Callable[[Fraction], int]"; expected "RoundingMethod"  [arg-type]
```

This happened since they properly added support for @enum.member (https://docs.python.org/3/library/enum.html#enum.member).

But, since @enum.member is only available since python 3.11, we need a workaround to fix mypy error.